### PR TITLE
Dependency & Maintenance update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
 				"@babel/register": "^7.22.15",
 				"@natlibfi/eslint-config-melinda-backend": "^3.0.3",
 				"cross-env": "^7.0.3",
-				"eslint": "^8.56.0"
+				"eslint": "^8.56.0",
+				"nodemon": "^3.0.2"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2354,6 +2355,12 @@
 				"node": ">=10.0.0"
 			}
 		},
+		"node_modules/abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
+		},
 		"node_modules/acorn": {
 			"version": "8.11.2",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
@@ -2415,7 +2422,6 @@
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
 			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
 			"dev": true,
-			"optional": true,
 			"dependencies": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -2567,7 +2573,6 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
 			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
 			"dev": true,
-			"optional": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2696,7 +2701,6 @@
 					"url": "https://paulmillr.com/funding/"
 				}
 			],
-			"optional": true,
 			"dependencies": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -4076,6 +4080,12 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/ignore-by-default": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+			"integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+			"dev": true
+		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4166,7 +4176,6 @@
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
 			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
 			"dev": true,
-			"optional": true,
 			"dependencies": {
 				"binary-extensions": "^2.0.0"
 			},
@@ -4905,12 +4914,87 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
 			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
 		},
+		"node_modules/nodemon": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.2.tgz",
+			"integrity": "sha512-9qIN2LNTrEzpOPBaWHTm4Asy1LxXLSickZStAQ4IZe7zsoIpD/A7LWxhZV3t4Zu352uBcqVnRsDXSMR2Sc3lTA==",
+			"dev": true,
+			"dependencies": {
+				"chokidar": "^3.5.2",
+				"debug": "^4",
+				"ignore-by-default": "^1.0.1",
+				"minimatch": "^3.1.2",
+				"pstree.remy": "^1.1.8",
+				"semver": "^7.5.3",
+				"simple-update-notifier": "^2.0.0",
+				"supports-color": "^5.5.0",
+				"touch": "^3.1.0",
+				"undefsafe": "^2.0.5"
+			},
+			"bin": {
+				"nodemon": "bin/nodemon.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/nodemon"
+			}
+		},
+		"node_modules/nodemon/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/nodemon/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/nodemon/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
+		"node_modules/nopt": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+			"integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+			"dev": true,
+			"dependencies": {
+				"abbrev": "1"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true,
-			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5279,6 +5363,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/pstree.remy": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+			"integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+			"dev": true
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5326,7 +5416,6 @@
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
 			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
 			"dev": true,
-			"optional": true,
 			"dependencies": {
 				"picomatch": "^2.2.1"
 			},
@@ -5659,6 +5748,51 @@
 				"is-arrayish": "^0.3.1"
 			}
 		},
+		"node_modules/simple-update-notifier": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+			"integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/simple-update-notifier/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/simple-update-notifier/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/simple-update-notifier/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
 		"node_modules/slash": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -5849,6 +5983,18 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/touch": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+			"integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+			"dev": true,
+			"dependencies": {
+				"nopt": "~1.0.10"
+			},
+			"bin": {
+				"nodetouch": "bin/nodetouch.js"
+			}
+		},
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -6020,6 +6166,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/undefsafe": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+			"integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+			"dev": true
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
 			"version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/passport-melinda-crowd",
-	"version": "3.0.2",
+	"version": "3.0.3-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/passport-melinda-crowd",
-			"version": "3.0.2",
+			"version": "3.0.3-alpha.1",
 			"license": "LGPL-3.0+",
 			"dependencies": {
 				"@natlibfi/melinda-backend-commons": "^2.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,23 +9,23 @@
 			"version": "3.0.2",
 			"license": "LGPL-3.0+",
 			"dependencies": {
-				"@natlibfi/melinda-backend-commons": "^2.2.1",
-				"@natlibfi/melinda-commons": "^13.0.6",
-				"@natlibfi/passport-atlassian-crowd": "^3.0.0",
+				"@natlibfi/melinda-backend-commons": "^2.2.4",
+				"@natlibfi/melinda-commons": "^13.0.9",
+				"@natlibfi/passport-atlassian-crowd": "^3.0.1",
 				"passport": "^0.6.0",
 				"passport-http": "^0.3.0",
 				"passport-http-bearer": "^1.0.1",
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.22.15",
-				"@babel/core": "^7.22.20",
+				"@babel/cli": "^7.23.4",
+				"@babel/core": "^7.23.6",
 				"@babel/node": "^7.22.19",
-				"@babel/preset-env": "^7.22.20",
+				"@babel/preset-env": "^7.23.6",
 				"@babel/register": "^7.22.15",
-				"@natlibfi/eslint-config-melinda-backend": "^3.0.2",
+				"@natlibfi/eslint-config-melinda-backend": "^3.0.3",
 				"cross-env": "^7.0.3",
-				"eslint": "^8.49.0"
+				"eslint": "^8.56.0"
 			},
 			"engines": {
 				"node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2040,14 +2040,14 @@
 			}
 		},
 		"node_modules/@natlibfi/passport-atlassian-crowd": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/passport-atlassian-crowd/-/passport-atlassian-crowd-3.0.0.tgz",
-			"integrity": "sha512-ORB34ifetIhrU5Hk1pz9YrFBlj5HgsuPeJwlST+lXwSrLaOwV6pOH06oGmBz/gPMS0N1PMT88Q0eNCiGF9GSmw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/passport-atlassian-crowd/-/passport-atlassian-crowd-3.0.1.tgz",
+			"integrity": "sha512-dtO1829k+WeEdHufjSeOt6fksbmLH3irrPQm5bqD8uh+qatREZXqsaKDlp9wSN84/JBmUwHNiw69lVyaQs9egQ==",
 			"dependencies": {
-				"@babel/register": "^7.22.5",
-				"http-status": "^1.6.2",
+				"@babel/register": "^7.22.15",
+				"http-status": "^1.7.0",
 				"moment": "^2.29.4",
-				"node-fetch": "^2.6.12",
+				"node-fetch": "^2.7.0",
 				"passport-strategy": "^1.0.0"
 			},
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/passport-melinda-crowd-js.git"
 	},
 	"license": "LGPL-3.0+",
-	"version": "3.0.2",
+	"version": "3.0.3-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -65,10 +65,10 @@
 		]
 	},
 	"nodemonConfig": {
-	  "exec": "npm run test:dev",
-	  "watch": [
-		"src/*",
-		"test-fixtures/*"
-	  ]
+		"exec": "npm run test:dev",
+		"watch": [
+			"src/*",
+			"test-fixtures/*"
+		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
 	},
 	"scripts": {
 		"prepare": "npm run build",
-		"lint": "eslint src",
-		"lint:dev": "eslint --fix src",
+		"lint": "eslint ./src",
+		"lint:dev": "eslint --fix ./src",
 		"test": "npm run lint",
 		"test:dev": "npm run lint:dev",
 		"build": "babel src --source-maps --copy-files --delete-dir-on-start --out-dir=dist",
-		"watch:test": "cross-env DEBUG=1 NODE_ENV=test nodemon -w src -w test-fixtures --exec 'npm run test:dev'"
+		"watch:test": "cross-env DEBUG=@natlibfi/* NODE_ENV=test nodemon"
 	},
 	"dependencies": {
 		"@natlibfi/melinda-backend-commons": "^2.2.4",
@@ -48,7 +48,8 @@
 		"@babel/register": "^7.22.15",
 		"@natlibfi/eslint-config-melinda-backend": "^3.0.3",
 		"cross-env": "^7.0.3",
-		"eslint": "^8.56.0"
+		"eslint": "^8.56.0",
+		"nodemon": "^3.0.2"
 	},
 	"eslintConfig": {
 		"extends": "@natlibfi/melinda-backend"
@@ -62,5 +63,12 @@
 				}
 			]
 		]
+	},
+	"nodemonConfig": {
+	  "exec": "npm run test:dev",
+	  "watch": [
+		"src/*",
+		"test-fixtures/*"
+	  ]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -32,23 +32,23 @@
 		"watch:test": "cross-env DEBUG=1 NODE_ENV=test nodemon -w src -w test-fixtures --exec 'npm run test:dev'"
 	},
 	"dependencies": {
-		"@natlibfi/melinda-backend-commons": "^2.2.1",
-		"@natlibfi/melinda-commons": "^13.0.6",
-		"@natlibfi/passport-atlassian-crowd": "^3.0.0",
+		"@natlibfi/melinda-backend-commons": "^2.2.4",
+		"@natlibfi/melinda-commons": "^13.0.9",
+		"@natlibfi/passport-atlassian-crowd": "^3.0.1",
 		"passport": "^0.6.0",
 		"passport-http": "^0.3.0",
 		"passport-http-bearer": "^1.0.1",
 		"uuid": "^9.0.1"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.22.15",
-		"@babel/core": "^7.22.20",
+		"@babel/cli": "^7.23.4",
+		"@babel/core": "^7.23.6",
 		"@babel/node": "^7.22.19",
-		"@babel/preset-env": "^7.22.20",
+		"@babel/preset-env": "^7.23.6",
 		"@babel/register": "^7.22.15",
-		"@natlibfi/eslint-config-melinda-backend": "^3.0.2",
+		"@natlibfi/eslint-config-melinda-backend": "^3.0.3",
 		"cross-env": "^7.0.3",
-		"eslint": "^8.49.0"
+		"eslint": "^8.56.0"
 	},
 	"eslintConfig": {
 		"extends": "@natlibfi/melinda-backend"


### PR DESCRIPTION
Bumps the production-dependencies group with 1 update: [@natlibfi/passport-atlassian-crowd](https://github.com/natlibfi/passport-atlassian-crowd-js).


Updates `@natlibfi/passport-atlassian-crowd` from 3.0.0 to 3.0.1
- [Release notes](https://github.com/natlibfi/passport-atlassian-crowd-js/releases)
- [Commits](https://github.com/natlibfi/passport-atlassian-crowd-js/compare/v3.0.0...v3.0.1)

---
updated-dependencies:
- dependency-name: "@natlibfi/passport-atlassian-crowd" dependency-type: direct:production update-type: version-update:semver-patch dependency-group: production-dependencies ...