### PR TITLE
Dependency update (#24)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5005,9 +5005,9 @@
 			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
 		},
 		"node_modules/nodemon": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.2.tgz",
-			"integrity": "sha512-9qIN2LNTrEzpOPBaWHTm4Asy1LxXLSickZStAQ4IZe7zsoIpD/A7LWxhZV3t4Zu352uBcqVnRsDXSMR2Sc3lTA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.3.tgz",
+			"integrity": "sha512-7jH/NXbFPxVaMwmBCC2B9F/V6X1VkEdNgx3iu9jji8WxWcvhMWkmhNWhI5077zknOnZnBzba9hZP6bCPJLSReQ==",
 			"dev": true,
 			"dependencies": {
 				"chokidar": "^3.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/passport-melinda-crowd",
-	"version": "3.0.4-alpha.1",
+	"version": "3.0.4-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/passport-melinda-crowd",
-			"version": "3.0.4-alpha.1",
+			"version": "3.0.4-alpha.2",
 			"license": "LGPL-3.0+",
 			"dependencies": {
 				"@natlibfi/melinda-backend-commons": "^2.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2044,9 +2044,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.5.tgz",
-			"integrity": "sha512-XbCYwBBnNdhGzhNKgA619u4yVVtI8MU5RmgWqdJwME6m1xvafRITPvYdjU1DlHgYPZ+F+cj/qfbvamw4/UkLdw==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.6.tgz",
+			"integrity": "sha512-BlAfjt1VH789dqmvMzKqGG8Gwj2TCkMGTiQ9FOIxbmWg1Wb6C6/OJCDSshB0JW7XNMMiVS4ZkOfDrOt4q1kmgA==",
 			"dependencies": {
 				"base64-url": "^2.3.3",
 				"debug": "^4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,28 @@
 {
 	"name": "@natlibfi/passport-melinda-crowd",
-	"version": "3.0.3",
+	"version": "3.0.4-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/passport-melinda-crowd",
-			"version": "3.0.3",
+			"version": "3.0.4-alpha.1",
 			"license": "LGPL-3.0+",
 			"dependencies": {
-				"@natlibfi/melinda-backend-commons": "^2.2.4",
-				"@natlibfi/melinda-commons": "^13.0.9",
+				"@natlibfi/melinda-backend-commons": "^2.2.5",
+				"@natlibfi/melinda-commons": "^13.0.11",
 				"@natlibfi/passport-atlassian-crowd": "^3.0.1",
-				"passport": "^0.6.0",
+				"passport": "^0.7.0",
 				"passport-http": "^0.3.0",
 				"passport-http-bearer": "^1.0.1",
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
 				"@babel/cli": "^7.23.4",
-				"@babel/core": "^7.23.6",
+				"@babel/core": "^7.23.7",
 				"@babel/node": "^7.22.19",
-				"@babel/preset-env": "^7.23.6",
-				"@babel/register": "^7.22.15",
+				"@babel/preset-env": "^7.23.8",
+				"@babel/register": "^7.23.7",
 				"@natlibfi/eslint-config-melinda-backend": "^3.0.3",
 				"cross-env": "^7.0.3",
 				"eslint": "^8.56.0",
@@ -103,19 +103,19 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.6.tgz",
-			"integrity": "sha512-FxpRyGjrMJXh7X3wGLGhNDCRiwpWEF74sKjTLDJSG5Kyvow3QZaG0Adbqzi9ZrVjTWpsX+2cxWXD71NMg93kdw==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
+			"integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.23.5",
 				"@babel/generator": "^7.23.6",
 				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helpers": "^7.23.6",
+				"@babel/helpers": "^7.23.7",
 				"@babel/parser": "^7.23.6",
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.6",
+				"@babel/traverse": "^7.23.7",
 				"@babel/types": "^7.23.6",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -203,9 +203,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.6.tgz",
-			"integrity": "sha512-cBXU1vZni/CpGF29iTu4YRbOZt3Wat6zCoMDxRF1MayiEc4URxOj31tT65HUM0CRpMowA3HCJaAOVOUnMf96cw==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.7.tgz",
+			"integrity": "sha512-xCoqR/8+BoNnXOY7RVSgv6X+o7pmT5q1d+gGcRlXYkI+9B31glE4jeejhKVpA04O1AtzOt7OSQ6VYKP5FcRl9g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
@@ -458,12 +458,12 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.6.tgz",
-			"integrity": "sha512-wCfsbN4nBidDRhpDhvcKlzHWCTlgJYUUdSJfzXb2NuBssDSIjc3xcb+znA7l+zYsFljAcGM0aFkN40cR3lXiGA==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
+			"integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
 			"dependencies": {
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.6",
+				"@babel/traverse": "^7.23.7",
 				"@babel/types": "^7.23.6"
 			},
 			"engines": {
@@ -550,9 +550,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.3.tgz",
-			"integrity": "sha512-XaJak1qcityzrX0/IU5nKHb34VaibwP3saKqG6a/tppelgllOH13LUann4ZCIBcVOeE6H18K4Vx9QKkVww3z/w==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.7.tgz",
+			"integrity": "sha512-LlRT7HgaifEpQA1ZgLVOIJZZFVPWN5iReq/7/JixwBtwcoeVGDBD53ZV28rrsLYOZs1Y/EHhA8N/Z6aazHR8cw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
@@ -828,9 +828,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.4.tgz",
-			"integrity": "sha512-efdkfPhHYTtn0G6n2ddrESE91fgXxjlqLsnUtPWnJs4a4mZIbUaK7ffqKIIUKXSHwcDvaCVX6GXkaJJFqtX7jw==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.7.tgz",
+			"integrity": "sha512-PdxEpL71bJp1byMG0va5gwQcXHxuEYC/BgI/e88mGTtohbZN28O5Yit0Plkkm/dBzCF/BxmbNcses1RH1T+urA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
@@ -926,16 +926,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.5.tgz",
-			"integrity": "sha512-jvOTR4nicqYC9yzOHIhXG5emiFEOpappSJAl73SDSEDcybD+Puuze8Tnpb9p9qEyYup24tq891gkaygIFvWDqg==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.8.tgz",
+			"integrity": "sha512-yAYslGsY1bX6Knmg46RjiCiNSwJKv2IUC8qOdYKqMMr0491SXFhcHqOdRDeCRohOOIzwN/90C6mQ9qAKgrP7dg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-optimise-call-expression": "^7.22.5",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/helper-replace-supers": "^7.22.20",
 				"@babel/helper-split-export-declaration": "^7.22.6",
@@ -1586,9 +1585,9 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.6.tgz",
-			"integrity": "sha512-2XPn/BqKkZCpzYhUUNZ1ssXw7DcXfKQEjv/uXZUXgaebCMYmkEsfZ2yY+vv+xtXv50WmL5SGhyB6/xsWxIvvOQ==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.8.tgz",
+			"integrity": "sha512-lFlpmkApLkEP6woIKprO6DO60RImpatTQKtz4sUcDjVcK8M8mQ4sZsuxaTMNOZf0sqAq/ReYW1ZBHnOQwKpLWA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.23.5",
@@ -1597,7 +1596,7 @@
 				"@babel/helper-validator-option": "^7.23.5",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.3",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.7",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -1618,13 +1617,13 @@
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.23.3",
-				"@babel/plugin-transform-async-generator-functions": "^7.23.4",
+				"@babel/plugin-transform-async-generator-functions": "^7.23.7",
 				"@babel/plugin-transform-async-to-generator": "^7.23.3",
 				"@babel/plugin-transform-block-scoped-functions": "^7.23.3",
 				"@babel/plugin-transform-block-scoping": "^7.23.4",
 				"@babel/plugin-transform-class-properties": "^7.23.3",
 				"@babel/plugin-transform-class-static-block": "^7.23.4",
-				"@babel/plugin-transform-classes": "^7.23.5",
+				"@babel/plugin-transform-classes": "^7.23.8",
 				"@babel/plugin-transform-computed-properties": "^7.23.3",
 				"@babel/plugin-transform-destructuring": "^7.23.3",
 				"@babel/plugin-transform-dotall-regex": "^7.23.3",
@@ -1666,9 +1665,9 @@
 				"@babel/plugin-transform-unicode-regex": "^7.23.3",
 				"@babel/plugin-transform-unicode-sets-regex": "^7.23.3",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.6",
-				"babel-plugin-polyfill-corejs3": "^0.8.5",
-				"babel-plugin-polyfill-regenerator": "^0.5.3",
+				"babel-plugin-polyfill-corejs2": "^0.4.7",
+				"babel-plugin-polyfill-corejs3": "^0.8.7",
+				"babel-plugin-polyfill-regenerator": "^0.5.4",
 				"core-js-compat": "^3.31.0",
 				"semver": "^6.3.1"
 			},
@@ -1694,14 +1693,14 @@
 			}
 		},
 		"node_modules/@babel/register": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.22.15.tgz",
-			"integrity": "sha512-V3Q3EqoQdn65RCgTLwauZaTfd1ShhwPmbBv+1dkZV/HpCGMKVyn6oFcRlI7RaKqiDQjX2Qd3AuoEguBgdjIKlg==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.23.7.tgz",
+			"integrity": "sha512-EjJeB6+kvpk+Y5DAkEAmbOBEFkh9OASx0huoEkqYTFxAZHzOAX2Oh5uwAUuL2rUddqfM0SA+KPXV2TbzoZ2kvQ==",
 			"dependencies": {
 				"clone-deep": "^4.0.1",
 				"find-cache-dir": "^2.0.0",
 				"make-dir": "^2.1.0",
-				"pirates": "^4.0.5",
+				"pirates": "^4.0.6",
 				"source-map-support": "^0.5.16"
 			},
 			"engines": {
@@ -1718,9 +1717,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
-			"integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
+			"integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
 			"dev": true,
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
@@ -1743,9 +1742,9 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.6.tgz",
-			"integrity": "sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+			"integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
 			"dependencies": {
 				"@babel/code-frame": "^7.23.5",
 				"@babel/generator": "^7.23.6",
@@ -1852,6 +1851,16 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
 			"version": "13.24.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -1867,6 +1876,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/@eslint/js": {
 			"version": "8.56.0",
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
@@ -1877,17 +1898,39 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.13",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+			"version": "0.11.14",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
 			"dev": true,
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.1",
-				"debug": "^4.1.1",
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
 			"engines": {
 				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -1904,9 +1947,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
 			"dev": true
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -1944,9 +1987,9 @@
 			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.20",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-			"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+			"version": "0.3.21",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
+			"integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2001,9 +2044,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.4.tgz",
-			"integrity": "sha512-nB+sWQtssDtIDCsIsEPJ/zRndNZKEUbq5dp8VtkhRgisoHWAlB527w8FXB8wYxIKsRqGb+daNCH6nqBr9GM6pw==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.5.tgz",
+			"integrity": "sha512-XbCYwBBnNdhGzhNKgA619u4yVVtI8MU5RmgWqdJwME6m1xvafRITPvYdjU1DlHgYPZ+F+cj/qfbvamw4/UkLdw==",
 			"dependencies": {
 				"base64-url": "^2.3.3",
 				"debug": "^4.3.4",
@@ -2022,18 +2065,18 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.9",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.9.tgz",
-			"integrity": "sha512-igMqCi/HJBcd30im5kbbUF56AhD9v+dye7VcLsxvT8Q1rW7dLoLHaglAsrH7O9QttMVkIQXDHeLwRL0jSIqLEQ==",
+			"version": "13.0.11",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.11.tgz",
+			"integrity": "sha512-IQRpKfSMwfNcOldOnoyWGxAs8v6TPDNVUa/mOq3eh13aLtwQFG/uQIGWFJkGBiwIQcd+C12Y4mHFLqdQOkI8UA==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^8.0.0",
+				"@natlibfi/marc-record": "^8.0.2",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
-				"@natlibfi/sru-client": "^6.0.7",
+				"@natlibfi/sru-client": "^6.0.8",
 				"debug": "^4.3.4",
 				"deep-eql": "^4.1.3",
 				"http-status": "^1.7.3",
-				"moment": "^2.29.4",
-				"nock": "^13.4.0",
+				"moment": "^2.30.1",
+				"nock": "^13.5.0",
 				"node-fetch": "^2.7.0"
 			},
 			"engines": {
@@ -2056,9 +2099,9 @@
 			}
 		},
 		"node_modules/@natlibfi/sru-client": {
-			"version": "6.0.7",
-			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.7.tgz",
-			"integrity": "sha512-mXWXXv0td7PlVd4p5rCPxSwggbZOnqyItm9zxvvwCob0ajdfKGsOi6i35TQ6RuiydrCW1IvuuvCNoEJHpz3bRw==",
+			"version": "6.0.8",
+			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.8.tgz",
+			"integrity": "sha512-U1zF9hhGv3HyfINxQlGO7TieaEq5CY0hGh0RM/4fR23vfj1yRm5bb60pZjk5SaLTFYkNyUC7iyNU7mjBzhii+g==",
 			"dependencies": {
 				"debug": "^4.3.4",
 				"http-status": "^1.7.3",
@@ -2138,13 +2181,13 @@
 			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.15.0.tgz",
-			"integrity": "sha512-+BdvxYBltqrmgCNu4Li+fGDIkW9n//NrruzG9X1vBzaNK+ExVXPoGB71kneaVw/Jp+4rH/vaMAGC6JfMbHstVg==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.18.1.tgz",
+			"integrity": "sha512-BgdBwXPFmZzaZUuw6wKiHKIovms97a7eTImjkXCZE04TGHysG+0hDQPmygyvgtkoB/aOQwSM/nWv3LzrOIQOBw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.15.0",
-				"@typescript-eslint/visitor-keys": "6.15.0"
+				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/visitor-keys": "6.18.1"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2155,13 +2198,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
-			"integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.18.1.tgz",
+			"integrity": "sha512-wyOSKhuzHeU/5pcRDP2G2Ndci+4g653V43gXTpt4nbyoIOAASkGDA9JIAgbQCdCkcr1MvpSYWzxTz0olCn8+/Q==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.15.0",
-				"@typescript-eslint/utils": "6.15.0",
+				"@typescript-eslint/typescript-estree": "6.18.1",
+				"@typescript-eslint/utils": "6.18.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -2182,9 +2225,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.15.0.tgz",
-			"integrity": "sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.18.1.tgz",
+			"integrity": "sha512-4TuMAe+tc5oA7wwfqMtB0Y5OrREPF1GeJBAjqwgZh1lEMH5PJQgWgHGfYufVB51LtjD+peZylmeyxUXPfENLCw==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2195,16 +2238,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.15.0.tgz",
-			"integrity": "sha512-7mVZJN7Hd15OmGuWrp2T9UvqR2Ecg+1j/Bp1jXUEY2GZKV6FXlOIoqVDmLpBiEiq3katvj/2n2mR0SDwtloCew==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.18.1.tgz",
+			"integrity": "sha512-fv9B94UAhywPRhUeeV/v+3SBDvcPiLxRZJw/xZeeGgRLQZ6rLMG+8krrJUyIf6s1ecWTzlsbp0rlw7n9sjufHA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.15.0",
-				"@typescript-eslint/visitor-keys": "6.15.0",
+				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/visitor-keys": "6.18.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
 				"semver": "^7.5.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -2255,17 +2299,17 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
-			"integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.18.1.tgz",
+			"integrity": "sha512-zZmTuVZvD1wpoceHvoQpOiewmWu3uP9FuTWo8vqpy2ffsmfCE8mklRPi+vmnIYAIk9t/4kOThri2QCDgor+OpQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.15.0",
-				"@typescript-eslint/types": "6.15.0",
-				"@typescript-eslint/typescript-estree": "6.15.0",
+				"@typescript-eslint/scope-manager": "6.18.1",
+				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/typescript-estree": "6.18.1",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -2313,12 +2357,12 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.15.0.tgz",
-			"integrity": "sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.18.1.tgz",
+			"integrity": "sha512-/kvt0C5lRqGoCfsbmm7/CwMqoSkY3zzHLIjdhHZQW3VFrnz7ATecOHR7nb7V+xn4286MBxfnQfQhAmCI0u+bJA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.15.0",
+				"@typescript-eslint/types": "6.18.1",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -2362,9 +2406,9 @@
 			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.11.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+			"version": "8.11.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2578,13 +2622,12 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/braces": {
@@ -2659,9 +2702,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001570",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
-			"integrity": "sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==",
+			"version": "1.0.30001576",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
+			"integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2809,9 +2852,9 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
 		},
 		"node_modules/core-js": {
-			"version": "3.34.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.34.0.tgz",
-			"integrity": "sha512-aDdvlDder8QmY91H88GzNi9EtQi2TjvQhpCX6B1v/dAZHU1AuLgHvRh54RiOerpEhEW46Tkf+vgAViB/CWC0ag==",
+			"version": "3.35.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.35.0.tgz",
+			"integrity": "sha512-ntakECeqg81KqMueeGJ79Q5ZgQNR+6eaE8sxGCx62zMbAIj65q+uYvatToew3m6eAGdU4gNZwpZ34NMe4GYswg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -2820,9 +2863,9 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.34.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.34.0.tgz",
-			"integrity": "sha512-4ZIyeNbW/Cn1wkMMDy+mvrRUxrwFNjKwbhCfQpDd+eLgYipDqp8oGFGtLmhh18EDPKA0g3VUBYOxQGGwvWLVpA==",
+			"version": "3.35.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.35.0.tgz",
+			"integrity": "sha512-5blwFAddknKeNgsjBzilkdQ0+YK8L1PfqPYq40NOYMYFSS38qj+hpTcLLWwpIwA2A5bje/x5jmVn2tzUMg9IVw==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.22.2"
@@ -2962,9 +3005,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.615",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.615.tgz",
-			"integrity": "sha512-/bKPPcgZVUziECqDc+0HkT87+0zhaWSZHNXqF8FLd2lQcptpmUFwoCSWjCdOng9Gdq+afKArPdEg/0ZW461Eng=="
+			"version": "1.4.630",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.630.tgz",
+			"integrity": "sha512-osHqhtjojpCsACVnuD11xO5g9xaCyw7Qqn/C2KParkMv42i8jrJJgx3g7mkHfpxwhy9MnOJr8+pKOdZ7qzgizg=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -3390,6 +3433,16 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/eslint/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/eslint/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3507,6 +3560,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/eslint/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/eslint/node_modules/supports-color": {
@@ -3899,6 +3964,28 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/glob/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/globals": {
@@ -4828,21 +4915,24 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
 			"dev": true,
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/moment": {
-			"version": "2.29.4",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+			"version": "2.30.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
 			"engines": {
 				"node": "*"
 			}
@@ -4859,9 +4949,9 @@
 			"dev": true
 		},
 		"node_modules/nock": {
-			"version": "13.4.0",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.4.0.tgz",
-			"integrity": "sha512-W8NVHjO/LCTNA64yxAPHV/K47LpGYcVzgKd3Q0n6owhwvD0Dgoterc25R4rnZbckJEb6Loxz1f5QMuJpJnbSyQ==",
+			"version": "13.5.0",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.5.0.tgz",
+			"integrity": "sha512-9hc1eCS2HtOz+sE9W7JQw/tXJktg0zoPSu48s/pYe73e25JW9ywiowbqnUSd7iZPeVawLcVpPZeZS312fwSY+g==",
 			"dependencies": {
 				"debug": "^4.1.0",
 				"json-stringify-safe": "^5.0.1",
@@ -4942,6 +5032,16 @@
 				"url": "https://opencollective.com/nodemon"
 			}
 		},
+		"node_modules/nodemon/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/nodemon/node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -4952,6 +5052,18 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/nodemon/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/nodemon/node_modules/semver": {
@@ -5148,9 +5260,9 @@
 			}
 		},
 		"node_modules/passport": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
-			"integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+			"integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
 			"dependencies": {
 				"passport-strategy": "1.x.x",
 				"pause": "0.0.1",
@@ -5631,14 +5743,17 @@
 			]
 		},
 		"node_modules/safe-regex-test": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.2.tgz",
+			"integrity": "sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.3",
+				"call-bind": "^1.0.5",
+				"get-intrinsic": "^1.2.2",
 				"is-regex": "^1.1.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -5666,15 +5781,16 @@
 			}
 		},
 		"node_modules/set-function-length": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+			"integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
 			"dev": true,
 			"dependencies": {
 				"define-data-property": "^1.1.1",
-				"get-intrinsic": "^1.2.1",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.2",
 				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.0"
+				"has-property-descriptors": "^1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/passport-melinda-crowd-js.git"
 	},
 	"license": "LGPL-3.0+",
-	"version": "3.0.4-alpha.1",
+	"version": "3.0.4-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/passport-melinda-crowd-js.git"
 	},
 	"license": "LGPL-3.0+",
-	"version": "3.0.3",
+	"version": "3.0.4-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -32,20 +32,20 @@
 		"watch:test": "cross-env DEBUG=@natlibfi/* NODE_ENV=test nodemon"
 	},
 	"dependencies": {
-		"@natlibfi/melinda-backend-commons": "^2.2.4",
-		"@natlibfi/melinda-commons": "^13.0.9",
+		"@natlibfi/melinda-backend-commons": "^2.2.5",
+		"@natlibfi/melinda-commons": "^13.0.11",
 		"@natlibfi/passport-atlassian-crowd": "^3.0.1",
-		"passport": "^0.6.0",
+		"passport": "^0.7.0",
 		"passport-http": "^0.3.0",
 		"passport-http-bearer": "^1.0.1",
 		"uuid": "^9.0.1"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.23.4",
-		"@babel/core": "^7.23.6",
+		"@babel/core": "^7.23.7",
 		"@babel/node": "^7.22.19",
-		"@babel/preset-env": "^7.23.6",
-		"@babel/register": "^7.22.15",
+		"@babel/preset-env": "^7.23.8",
+		"@babel/register": "^7.23.7",
 		"@natlibfi/eslint-config-melinda-backend": "^3.0.3",
 		"cross-env": "^7.0.3",
 		"eslint": "^8.56.0",


### PR DESCRIPTION
* Bump the development-dependencies group with 3 updates (#23) Updates `@babel/core` from 7.23.6 to 7.23.7
Updates `@babel/preset-env` from 7.23.6 to 7.23.8
Updates `@babel/register` from 7.22.15 to 7.23.7

* Bump the production-dependencies group with 2 updates (#21) Updates `@natlibfi/melinda-backend-commons` from 2.2.4 to 2.2.5 Updates `@natlibfi/melinda-commons` from 13.0.9 to 13.0.10

* Update deps

* 3.0.4-alpha.1