### PR TITLE
Dependency & Maintenance update (#45)

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 21.x, 22.x]
+        node-version: [18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "@natlibfi/passport-melinda-crowd",
-	"version": "3.0.5",
+	"version": "3.0.6-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/passport-melinda-crowd",
-			"version": "3.0.5",
-			"license": "LGPL-3.0+",
+			"version": "3.0.6-alpha.2",
+			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/melinda-backend-commons": "^2.2.6",
-				"@natlibfi/melinda-commons": "^13.0.13",
+				"@natlibfi/melinda-backend-commons": "^2.3.0",
+				"@natlibfi/melinda-commons": "^13.0.15",
 				"@natlibfi/passport-atlassian-crowd": "^3.0.1",
 				"passport": "^0.7.0",
 				"passport-http": "^0.3.0",
@@ -18,15 +18,15 @@
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.24.5",
-				"@babel/core": "^7.24.5",
-				"@babel/node": "^7.23.9",
-				"@babel/preset-env": "^7.24.5",
-				"@babel/register": "^7.23.7",
-				"@natlibfi/eslint-config-melinda-backend": "^3.0.4",
+				"@babel/cli": "^7.24.7",
+				"@babel/core": "^7.24.7",
+				"@babel/node": "^7.24.7",
+				"@babel/preset-env": "^7.24.7",
+				"@babel/register": "^7.24.6",
+				"@natlibfi/eslint-config-melinda-backend": "^3.0.5",
 				"cross-env": "^7.0.3",
 				"eslint": "^8.57.0",
-				"nodemon": "^3.1.0"
+				"nodemon": "^3.1.4"
 			},
 			"engines": {
 				"node": ">=18"
@@ -45,13 +45,13 @@
 			}
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.24.5.tgz",
-			"integrity": "sha512-2qg1mYtJRsOOWF6IUwLP5jI42P8Cc0hQ5TmnjLrik/4DKouO8dFJN80HEz81VmVeUs97yuuf3vQ/9j7Elrcjlg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.24.7.tgz",
+			"integrity": "sha512-8dfPprJgV4O14WTx+AQyEA+opgUKPrsIXX/MdL50J1n06EQJ6m1T+CdsJe0qEC0B/Xl85i+Un5KVAxd/PACX9A==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
-				"commander": "^4.0.1",
+				"commander": "^6.2.0",
 				"convert-source-map": "^2.0.0",
 				"fs-readdir-recursive": "^1.1.0",
 				"glob": "^7.2.0",
@@ -74,11 +74,11 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.24.2",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
 			"dependencies": {
-				"@babel/highlight": "^7.24.2",
+				"@babel/highlight": "^7.24.7",
 				"picocolors": "^1.0.0"
 			},
 			"engines": {
@@ -86,28 +86,28 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.24.4",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
-			"integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
+			"integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.5.tgz",
-			"integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
+			"integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.24.2",
-				"@babel/generator": "^7.24.5",
-				"@babel/helper-compilation-targets": "^7.23.6",
-				"@babel/helper-module-transforms": "^7.24.5",
-				"@babel/helpers": "^7.24.5",
-				"@babel/parser": "^7.24.5",
-				"@babel/template": "^7.24.0",
-				"@babel/traverse": "^7.24.5",
-				"@babel/types": "^7.24.5",
+				"@babel/code-frame": "^7.24.7",
+				"@babel/generator": "^7.24.7",
+				"@babel/helper-compilation-targets": "^7.24.7",
+				"@babel/helper-module-transforms": "^7.24.7",
+				"@babel/helpers": "^7.24.7",
+				"@babel/parser": "^7.24.7",
+				"@babel/template": "^7.24.7",
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -123,9 +123,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.5.tgz",
-			"integrity": "sha512-gsUcqS/fPlgAw1kOtpss7uhY6E9SFFANQ6EFX5GTvzUwaV0+sGaZWk6xq22MOdeT9wfxyokW3ceCUvOiRtZciQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.7.tgz",
+			"integrity": "sha512-SO5E3bVxDuxyNxM5agFv480YA2HO6ohZbGxbazZdIk3KQOPOGVNw6q78I9/lbviIf95eq6tPozeYnJLbjnC8IA==",
 			"dev": true,
 			"dependencies": {
 				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -141,11 +141,11 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
-			"integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+			"integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
 			"dependencies": {
-				"@babel/types": "^7.24.5",
+				"@babel/types": "^7.24.7",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
@@ -155,36 +155,37 @@
 			}
 		},
 		"node_modules/@babel/helper-annotate-as-pure": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-			"integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+			"integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.22.5"
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.22.15.tgz",
-			"integrity": "sha512-QkBXwGgaoC2GtGZRoma6kv7Szfv06khvhFav67ZExau2RaXzy8MpHSMO2PNoP2XtmQphJQRHFfg77Bq731Yizw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.24.7.tgz",
+			"integrity": "sha512-xZeCVVdwb4MsDBkkyZ64tReWYrLRHlMN72vP7Bdm3OUOuyFZExhsHUUnuWnm2/XOlAJzR0LfPpB56WXZn0X/lA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.22.15"
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-			"integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
+			"integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
 			"dependencies": {
-				"@babel/compat-data": "^7.23.5",
-				"@babel/helper-validator-option": "^7.23.5",
+				"@babel/compat-data": "^7.24.7",
+				"@babel/helper-validator-option": "^7.24.7",
 				"browserslist": "^4.22.2",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -194,19 +195,19 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.5.tgz",
-			"integrity": "sha512-uRc4Cv8UQWnE4NXlYTIIdM7wfFkOqlFztcC/gVXDKohKoVB3OyonfelUBaJzSwpBntZ2KYGF/9S7asCHsXwW6g==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.7.tgz",
+			"integrity": "sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-member-expression-to-functions": "^7.24.5",
-				"@babel/helper-optimise-call-expression": "^7.22.5",
-				"@babel/helper-replace-supers": "^7.24.1",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.24.5",
+				"@babel/helper-annotate-as-pure": "^7.24.7",
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-function-name": "^7.24.7",
+				"@babel/helper-member-expression-to-functions": "^7.24.7",
+				"@babel/helper-optimise-call-expression": "^7.24.7",
+				"@babel/helper-replace-supers": "^7.24.7",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+				"@babel/helper-split-export-declaration": "^7.24.7",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -217,12 +218,12 @@
 			}
 		},
 		"node_modules/@babel/helper-create-regexp-features-plugin": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.15.tgz",
-			"integrity": "sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.24.7.tgz",
+			"integrity": "sha512-03TCmXy2FtXJEZfbXDTSqq1fRJArk7lX9DOFC/47VthYcxyIOx+eXQmdo6DOQvrbpIix+KfXwvuXdFDZHxt+rA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
+				"@babel/helper-annotate-as-pure": "^7.24.7",
 				"regexpu-core": "^5.3.1",
 				"semver": "^6.3.1"
 			},
@@ -250,69 +251,74 @@
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+			"integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+			"dependencies": {
+				"@babel/types": "^7.24.7"
+			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+			"integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
 			"dependencies": {
-				"@babel/template": "^7.22.15",
-				"@babel/types": "^7.23.0"
+				"@babel/template": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+			"integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
 			"dependencies": {
-				"@babel/types": "^7.22.5"
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.5.tgz",
-			"integrity": "sha512-4owRteeihKWKamtqg4JmWSsEZU445xpFRXPEwp44HbgbxdWlUV1b4Agg4lkA806Lil5XM/e+FJyS0vj5T6vmcA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.7.tgz",
+			"integrity": "sha512-LGeMaf5JN4hAT471eJdBs/GK1DoYIJ5GCtZN/EsL6KUiiDZOvO/eKE11AMZJa2zP4zk4qe9V2O/hxAmkRc8p6w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.24.5"
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.24.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
-			"integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+			"integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
 			"dependencies": {
-				"@babel/types": "^7.24.0"
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz",
-			"integrity": "sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
+			"integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-module-imports": "^7.24.3",
-				"@babel/helper-simple-access": "^7.24.5",
-				"@babel/helper-split-export-declaration": "^7.24.5",
-				"@babel/helper-validator-identifier": "^7.24.5"
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-module-imports": "^7.24.7",
+				"@babel/helper-simple-access": "^7.24.7",
+				"@babel/helper-split-export-declaration": "^7.24.7",
+				"@babel/helper-validator-identifier": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -322,35 +328,35 @@
 			}
 		},
 		"node_modules/@babel/helper-optimise-call-expression": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
-			"integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
+			"integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.22.5"
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
-			"integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+			"integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-remap-async-to-generator": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.20.tgz",
-			"integrity": "sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.24.7.tgz",
+			"integrity": "sha512-9pKLcTlZ92hNZMQfGCHImUpDOlAgkkpqalWEeftW5FBya75k8Li2ilerxkM/uBEj01iBZXcCIB/bwvDYgWyibA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-wrap-function": "^7.22.20"
+				"@babel/helper-annotate-as-pure": "^7.24.7",
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-wrap-function": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -360,14 +366,14 @@
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.1.tgz",
-			"integrity": "sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.7.tgz",
+			"integrity": "sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-member-expression-to-functions": "^7.23.0",
-				"@babel/helper-optimise-call-expression": "^7.22.5"
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-member-expression-to-functions": "^7.24.7",
+				"@babel/helper-optimise-call-expression": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -377,96 +383,98 @@
 			}
 		},
 		"node_modules/@babel/helper-simple-access": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.5.tgz",
-			"integrity": "sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+			"integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
 			"dependencies": {
-				"@babel/types": "^7.24.5"
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
-			"integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
+			"integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.22.5"
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
-			"integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+			"integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
 			"dependencies": {
-				"@babel/types": "^7.24.5"
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-			"integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+			"integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-			"integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-			"integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
+			"integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.24.5.tgz",
-			"integrity": "sha512-/xxzuNvgRl4/HLNKvnFwdhdgN3cpLxgLROeLDl83Yx0AJ1SGvq1ak0OszTOjDfiB8Vx03eJbeDWh9r+jCCWttw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.24.7.tgz",
+			"integrity": "sha512-N9JIYk3TD+1vq/wn77YnJOqMtfWhNewNE+DJV4puD2X7Ew9J4JvrzrFDfTfyv5EgEXVy9/Wt8QiOErzEmv5Ifw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/template": "^7.24.0",
-				"@babel/types": "^7.24.5"
+				"@babel/helper-function-name": "^7.24.7",
+				"@babel/template": "^7.24.7",
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.5.tgz",
-			"integrity": "sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
+			"integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
 			"dependencies": {
-				"@babel/template": "^7.24.0",
-				"@babel/traverse": "^7.24.5",
-				"@babel/types": "^7.24.5"
+				"@babel/template": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
-			"integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.24.5",
+				"@babel/helper-validator-identifier": "^7.24.7",
 				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.0.0"
@@ -476,13 +484,13 @@
 			}
 		},
 		"node_modules/@babel/node": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/node/-/node-7.23.9.tgz",
-			"integrity": "sha512-/d4ju/POwlGIJlZ+NqWH1qu61wt6ZlTZZZutrK2MOSdaH1JCh726nLw/GSvAjG+LTY6CO9SsB8uWcttnFKm6yg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/node/-/node-7.24.7.tgz",
+			"integrity": "sha512-BCYNLxUQjGTgy8bAq12jy+Lt8soGWa/5u3s7U3aTVXxviIp0YVS+/Wm0b4eaitLVvetYrEoAiRF0QOk4WKsHAQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/register": "^7.23.7",
-				"commander": "^4.0.1",
+				"@babel/register": "^7.24.6",
+				"commander": "^6.2.0",
 				"core-js": "^3.30.2",
 				"node-environment-flags": "^1.0.5",
 				"regenerator-runtime": "^0.14.0",
@@ -499,9 +507,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-			"integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+			"integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -510,13 +518,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.24.5.tgz",
-			"integrity": "sha512-LdXRi1wEMTrHVR4Zc9F8OewC3vdm5h4QB6L71zy6StmYeqGi1b3ttIO8UC+BfZKcH9jdr4aI249rBkm+3+YvHw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.24.7.tgz",
+			"integrity": "sha512-TiT1ss81W80eQsN+722OaeQMY/G4yTb4G9JrqeiDADs3N8lbPMGldWi9x8tyqCW5NLx1Jh2AvkE6r6QvEltMMQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-plugin-utils": "^7.24.5"
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -526,12 +534,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.24.1.tgz",
-			"integrity": "sha512-y4HqEnkelJIOQGd+3g1bTeKsA5c6qM7eOn7VggGVbBc0y8MLSKHacwcIE2PplNlQSj0PqS9rrXL/nkPVK+kUNg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.24.7.tgz",
+			"integrity": "sha512-unaQgZ/iRu/By6tsjMZzpeBZjChYfLYry6HrEXPoz3KmfF0sVBQ1l8zKMQ4xRGLWVsjuvB8nQfjNP/DcfEOCsg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -541,14 +549,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.24.1.tgz",
-			"integrity": "sha512-Hj791Ii4ci8HqnaKHAlLNs+zaLXb0EzSDhiAWp5VNlyvCNymYfacs64pxTxbH1znW/NcArSmwpmG9IKE/TUVVQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.24.7.tgz",
+			"integrity": "sha512-+izXIbke1T33mY4MSNnrqhPXDz01WYhEf3yF5NbnUtkiNnm+XBZJl3kNfoK6NKmYlz/D07+l2GWVK/QfDkNCuQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-				"@babel/plugin-transform-optional-chaining": "^7.24.1"
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+				"@babel/plugin-transform-optional-chaining": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -558,13 +566,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.24.1.tgz",
-			"integrity": "sha512-m9m/fXsXLiHfwdgydIFnpk+7jlVbnvlK5B2EKiPdLUb6WX654ZaaEWJUjk8TftRbZpK0XibovlLWX4KIZhV6jw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.24.7.tgz",
+			"integrity": "sha512-utA4HuR6F4Vvcr+o4DnjL8fCOlgRFGbeeBEGNg3ZTrLFw6VWG5XmUrvcQ0FjIYMU2ST4XcR2Wsp7t9qOAPnxMg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -649,12 +657,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-assertions": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.1.tgz",
-			"integrity": "sha512-IuwnI5XnuF189t91XbxmXeCDz3qs6iDRO7GJ++wcfgeXNs/8FmIlKcpDSXNVyuLQxlwvskmI3Ct73wUODkJBlQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.7.tgz",
+			"integrity": "sha512-Ec3NRUMoi8gskrkBe3fNmEQfxDvY8bgfQpz6jlk/41kX9eUjvpyqWU7PBP/pLAvMaSQjbMNKJmvX57jP+M6bPg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -664,12 +672,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.1.tgz",
-			"integrity": "sha512-zhQTMH0X2nVLnb04tz+s7AMuasX8U0FnpE+nHTOhSOINjWMnopoZTxtIKsd45n4GQ/HIZLyfIpoul8e2m0DnRA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.7.tgz",
+			"integrity": "sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -821,12 +829,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-arrow-functions": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.24.1.tgz",
-			"integrity": "sha512-ngT/3NkRhsaep9ck9uj2Xhv9+xB1zShY3tM3g6om4xxCELwCDN4g4Aq5dRn48+0hasAql7s2hdBOysCfNpr4fw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.24.7.tgz",
+			"integrity": "sha512-Dt9LQs6iEY++gXUwY03DNFat5C2NbO48jj+j/bSAz6b3HgPs39qcPiYt77fDObIcFwj3/C2ICX9YMwGflUoSHQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -836,14 +844,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.24.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.3.tgz",
-			"integrity": "sha512-Qe26CMYVjpQxJ8zxM1340JFNjZaF+ISWpr1Kt/jGo+ZTUzKkfw/pphEWbRCb+lmSM6k/TOgfYLvmbHkUQ0asIg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.7.tgz",
+			"integrity": "sha512-o+iF77e3u7ZS4AoAuJvapz9Fm001PuD2V3Lp6OSE4FYQke+cSewYtnek+THqGRWyQloRCyvWL1OkyfNEl9vr/g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-plugin-utils": "^7.24.0",
-				"@babel/helper-remap-async-to-generator": "^7.22.20",
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-remap-async-to-generator": "^7.24.7",
 				"@babel/plugin-syntax-async-generators": "^7.8.4"
 			},
 			"engines": {
@@ -854,14 +862,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-to-generator": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.24.1.tgz",
-			"integrity": "sha512-AawPptitRXp1y0n4ilKcGbRYWfbbzFWz2NqNu7dacYDtFtz0CMjG64b3LQsb3KIgnf4/obcUL78hfaOS7iCUfw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.24.7.tgz",
+			"integrity": "sha512-SQY01PcJfmQ+4Ash7NE+rpbLFbmqA2GPIgqzxfFTL4t1FKRq4zTms/7htKpoCUI9OcFYgzqfmCdH53s6/jn5fA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.24.1",
-				"@babel/helper-plugin-utils": "^7.24.0",
-				"@babel/helper-remap-async-to-generator": "^7.22.20"
+				"@babel/helper-module-imports": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-remap-async-to-generator": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -871,12 +879,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.1.tgz",
-			"integrity": "sha512-TWWC18OShZutrv9C6mye1xwtam+uNi2bnTOCBUd5sZxyHOiWbU6ztSROofIMrK84uweEZC219POICK/sTYwfgg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.7.tgz",
+			"integrity": "sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -886,12 +894,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.5.tgz",
-			"integrity": "sha512-sMfBc3OxghjC95BkYrYocHL3NaOplrcaunblzwXhGmlPwpmfsxr4vK+mBBt49r+S240vahmv+kUxkeKgs+haCw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.7.tgz",
+			"integrity": "sha512-Nd5CvgMbWc+oWzBsuaMcbwjJWAcp5qzrbg69SZdHSP7AMY0AbWFqFO0WTFCA1jxhMCwodRwvRec8k0QUbZk7RQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.5"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -901,13 +909,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-properties": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.1.tgz",
-			"integrity": "sha512-OMLCXi0NqvJfORTaPQBwqLXHhb93wkBKZ4aNwMl6WtehO7ar+cmp+89iPEQPqxAnxsOKTaMcs3POz3rKayJ72g==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.7.tgz",
+			"integrity": "sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.24.1",
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-create-class-features-plugin": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -917,13 +925,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-static-block": {
-			"version": "7.24.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.4.tgz",
-			"integrity": "sha512-B8q7Pz870Hz/q9UgP8InNpY01CSLDSCyqX7zcRuv3FcPl87A2G17lASroHWaCtbdIcbYzOZ7kWmXFKbijMSmFg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.7.tgz",
+			"integrity": "sha512-HMXK3WbBPpZQufbMG4B46A90PkuuhN9vBCb5T8+VAHqvAqvcLi+2cKoukcpmUYkszLhScU3l1iudhrks3DggRQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.24.4",
-				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/helper-create-class-features-plugin": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5"
 			},
 			"engines": {
@@ -934,18 +942,18 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.5.tgz",
-			"integrity": "sha512-gWkLP25DFj2dwe9Ck8uwMOpko4YsqyfZJrOmqqcegeDYEbp7rmn4U6UQZNj08UF6MaX39XenSpKRCvpDRBtZ7Q==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.7.tgz",
+			"integrity": "sha512-CFbbBigp8ln4FU6Bpy6g7sE8B/WmCmzvivzUC6xDAdWVsjYTXijpuuGJmYkAaoWAzcItGKT3IOAbxRItZ5HTjw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-compilation-targets": "^7.23.6",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-plugin-utils": "^7.24.5",
-				"@babel/helper-replace-supers": "^7.24.1",
-				"@babel/helper-split-export-declaration": "^7.24.5",
+				"@babel/helper-annotate-as-pure": "^7.24.7",
+				"@babel/helper-compilation-targets": "^7.24.7",
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-function-name": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-replace-supers": "^7.24.7",
+				"@babel/helper-split-export-declaration": "^7.24.7",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -956,13 +964,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-computed-properties": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.24.1.tgz",
-			"integrity": "sha512-5pJGVIUfJpOS+pAqBQd+QMaTD2vCL/HcePooON6pDpHgRp4gNRmzyHTPIkXntwKsq3ayUFVfJaIKPw2pOkOcTw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.24.7.tgz",
+			"integrity": "sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
-				"@babel/template": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/template": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -972,12 +980,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.5.tgz",
-			"integrity": "sha512-SZuuLyfxvsm+Ah57I/i1HVjveBENYK9ue8MJ7qkc7ndoNjqquJiElzA7f5yaAXjyW2hKojosOTAQQRX50bPSVg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.7.tgz",
+			"integrity": "sha512-19eJO/8kdCQ9zISOf+SEUJM/bAUIsvY3YDnXZTupUCQ8LgrWnsG/gFB9dvXqdXnRXMAM8fvt7b0CBKQHNGy1mw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.5"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -987,13 +995,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-dotall-regex": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.24.1.tgz",
-			"integrity": "sha512-p7uUxgSoZwZ2lPNMzUkqCts3xlp8n+o05ikjy7gbtFJSt9gdU88jAmtfmOxHM14noQXBxfgzf2yRWECiNVhTCw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.24.7.tgz",
+			"integrity": "sha512-ZOA3W+1RRTSWvyqcMJDLqbchh7U4NRGqwRfFSVbOLS/ePIP4vHB5e8T8eXcuqyN1QkgKyj5wuW0lcS85v4CrSw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1003,12 +1011,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-duplicate-keys": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.24.1.tgz",
-			"integrity": "sha512-msyzuUnvsjsaSaocV6L7ErfNsa5nDWL1XKNnDePLgmz+WdU4w/J8+AxBMrWfi9m4IxfL5sZQKUPQKDQeeAT6lA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.24.7.tgz",
+			"integrity": "sha512-JdYfXyCRihAe46jUIliuL2/s0x0wObgwwiGxw/UbgJBr20gQBThrokO4nYKgWkD7uBaqM7+9x5TU7NkExZJyzw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1018,12 +1026,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-dynamic-import": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.24.1.tgz",
-			"integrity": "sha512-av2gdSTyXcJVdI+8aFZsCAtR29xJt0S5tas+Ef8NvBNmD1a+N/3ecMLeMBgfcK+xzsjdLDT6oHt+DFPyeqUbDA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.24.7.tgz",
+			"integrity": "sha512-sc3X26PhZQDb3JhORmakcbvkeInvxz+A8oda99lj7J60QRuPZvNAk9wQlTBS1ZynelDrDmTU4pw1tyc5d5ZMUg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3"
 			},
 			"engines": {
@@ -1034,13 +1042,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.24.1.tgz",
-			"integrity": "sha512-U1yX13dVBSwS23DEAqU+Z/PkwE9/m7QQy8Y9/+Tdb8UWYaGNDYwTLi19wqIAiROr8sXVum9A/rtiH5H0boUcTw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.24.7.tgz",
+			"integrity": "sha512-Rqe/vSc9OYgDajNIK35u7ot+KeCoetqQYFXM4Epf7M7ez3lWlOjrDjrwMei6caCVhfdw+mIKD4cgdGNy5JQotQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1050,12 +1058,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-export-namespace-from": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.24.1.tgz",
-			"integrity": "sha512-Ft38m/KFOyzKw2UaJFkWG9QnHPG/Q/2SkOrRk4pNBPg5IPZ+dOxcmkK5IyuBcxiNPyyYowPGUReyBvrvZs7IlQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.24.7.tgz",
+			"integrity": "sha512-v0K9uNYsPL3oXZ/7F9NNIbAj2jv1whUEtyA6aujhekLs56R++JDQuzRcP2/z4WX5Vg/c5lE9uWZA0/iUoFhLTA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
 			},
 			"engines": {
@@ -1066,13 +1074,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-for-of": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.1.tgz",
-			"integrity": "sha512-OxBdcnF04bpdQdR3i4giHZNZQn7cm8RQKcSwA17wAAqEELo1ZOwp5FFgeptWUQXFyT9kwHo10aqqauYkRZPCAg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.7.tgz",
+			"integrity": "sha512-wo9ogrDG1ITTTBsy46oGiN1dS9A7MROBTcYsfS8DtsImMkHk9JXJ3EWQM6X2SUw4x80uGPlwj0o00Uoc6nEE3g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1082,14 +1090,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-function-name": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.24.1.tgz",
-			"integrity": "sha512-BXmDZpPlh7jwicKArQASrj8n22/w6iymRnvHYYd2zO30DbE277JO20/7yXJT3QxDPtiQiOxQBbZH4TpivNXIxA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.24.7.tgz",
+			"integrity": "sha512-U9FcnA821YoILngSmYkW6FjyQe2TyZD5pHt4EVIhmcTkrJw/3KqcrRSxuOo5tFZJi7TE19iDyI1u+weTI7bn2w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.23.6",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-compilation-targets": "^7.24.7",
+				"@babel/helper-function-name": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1099,12 +1107,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-json-strings": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.24.1.tgz",
-			"integrity": "sha512-U7RMFmRvoasscrIFy5xA4gIp8iWnWubnKkKuUGJjsuOH7GfbMkB+XZzeslx2kLdEGdOJDamEmCqOks6e8nv8DQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.24.7.tgz",
+			"integrity": "sha512-2yFnBGDvRuxAaE/f0vfBKvtnvvqU8tGpMHqMNpTN2oWMKIR3NqFkjaAgGwawhqK/pIN2T3XdjGPdaG0vDhOBGw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/plugin-syntax-json-strings": "^7.8.3"
 			},
 			"engines": {
@@ -1115,12 +1123,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-literals": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.24.1.tgz",
-			"integrity": "sha512-zn9pwz8U7nCqOYIiBaOxoQOtYmMODXTJnkxG4AtX8fPmnCRYWBOHD0qcpwS9e2VDSp1zNJYpdnFMIKb8jmwu6g==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.24.7.tgz",
+			"integrity": "sha512-vcwCbb4HDH+hWi8Pqenwnjy+UiklO4Kt1vfspcQYFhJdpthSnW8XvWGyDZWKNVrVbVViI/S7K9PDJZiUmP2fYQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1130,12 +1138,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-logical-assignment-operators": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.24.1.tgz",
-			"integrity": "sha512-OhN6J4Bpz+hIBqItTeWJujDOfNP+unqv/NJgyhlpSqgBTPm37KkMmZV6SYcOj+pnDbdcl1qRGV/ZiIjX9Iy34w==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.24.7.tgz",
+			"integrity": "sha512-4D2tpwlQ1odXmTEIFWy9ELJcZHqrStlzK/dAOWYyxX3zT0iXQB6banjgeOJQXzEc4S0E0a5A+hahxPaEFYftsw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
 			},
 			"engines": {
@@ -1146,12 +1154,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-member-expression-literals": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.1.tgz",
-			"integrity": "sha512-4ojai0KysTWXzHseJKa1XPNXKRbuUrhkOPY4rEGeR+7ChlJVKxFa3H3Bz+7tWaGKgJAXUWKOGmltN+u9B3+CVg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.7.tgz",
+			"integrity": "sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1161,13 +1169,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-amd": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.24.1.tgz",
-			"integrity": "sha512-lAxNHi4HVtjnHd5Rxg3D5t99Xm6H7b04hUS7EHIXcUl2EV4yl1gWdqZrNzXnSrHveL9qMdbODlLF55mvgjAfaQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.24.7.tgz",
+			"integrity": "sha512-9+pB1qxV3vs/8Hdmz/CulFB8w2tuu6EB94JZFsjdqxQokwGa9Unap7Bo2gGBGIvPmDIVvQrom7r5m/TCDMURhg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-module-transforms": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1177,14 +1185,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.1.tgz",
-			"integrity": "sha512-szog8fFTUxBfw0b98gEWPaEqF42ZUD/T3bkynW/wtgx2p/XCP55WEsb+VosKceRSd6njipdZvNogqdtI4Q0chw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.7.tgz",
+			"integrity": "sha512-iFI8GDxtevHJ/Z22J5xQpVqFLlMNstcLXh994xifFwxxGslr2ZXXLWgtBeLctOD63UFDArdvN6Tg8RFw+aEmjQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helper-plugin-utils": "^7.24.0",
-				"@babel/helper-simple-access": "^7.22.5"
+				"@babel/helper-module-transforms": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-simple-access": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1194,15 +1202,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.24.1.tgz",
-			"integrity": "sha512-mqQ3Zh9vFO1Tpmlt8QPnbwGHzNz3lpNEMxQb1kAemn/erstyqw1r9KeOlOfo3y6xAnFEcOv2tSyrXfmMk+/YZA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.24.7.tgz",
+			"integrity": "sha512-GYQE0tW7YoaN13qFh3O1NCY4MPkUiAH3fiF7UcV/I3ajmDKEdG3l+UOcbAm4zUE3gnvUU+Eni7XrVKo9eO9auw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-hoist-variables": "^7.22.5",
-				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helper-plugin-utils": "^7.24.0",
-				"@babel/helper-validator-identifier": "^7.22.20"
+				"@babel/helper-hoist-variables": "^7.24.7",
+				"@babel/helper-module-transforms": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-validator-identifier": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1212,13 +1220,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-umd": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.24.1.tgz",
-			"integrity": "sha512-tuA3lpPj+5ITfcCluy6nWonSL7RvaG0AOTeAuvXqEKS34lnLzXpDb0dcP6K8jD0zWZFNDVly90AGFJPnm4fOYg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.24.7.tgz",
+			"integrity": "sha512-3aytQvqJ/h9z4g8AsKPLvD4Zqi2qT+L3j7XoFFu1XBlZWEl2/1kWnhmAbxpLgPrHSY0M6UA02jyTiwUVtiKR6A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-module-transforms": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1228,13 +1236,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.22.5.tgz",
-			"integrity": "sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.24.7.tgz",
+			"integrity": "sha512-/jr7h/EWeJtk1U/uz2jlsCioHkZk1JJZVcc8oQsJ1dUlaJD83f4/6Zeh2aHt9BIFokHIsSeDfhUmju0+1GPd6g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.5",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-create-regexp-features-plugin": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1244,12 +1252,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-new-target": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.24.1.tgz",
-			"integrity": "sha512-/rurytBM34hYy0HKZQyA0nHbQgQNFm4Q/BOc9Hflxi2X3twRof7NaE5W46j4kQitm7SvACVRXsa6N/tSZxvPug==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.24.7.tgz",
+			"integrity": "sha512-RNKwfRIXg4Ls/8mMTza5oPF5RkOW8Wy/WgMAp1/F1yZ8mMbtwXW+HDoJiOsagWrAhI5f57Vncrmr9XeT4CVapA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1259,12 +1267,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.24.1.tgz",
-			"integrity": "sha512-iQ+caew8wRrhCikO5DrUYx0mrmdhkaELgFa+7baMcVuhxIkN7oxt06CZ51D65ugIb1UWRQ8oQe+HXAVM6qHFjw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.24.7.tgz",
+			"integrity": "sha512-Ts7xQVk1OEocqzm8rHMXHlxvsfZ0cEF2yomUqpKENHWMF4zKk175Y4q8H5knJes6PgYad50uuRmt3UJuhBw8pQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
 			},
 			"engines": {
@@ -1275,12 +1283,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-numeric-separator": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.24.1.tgz",
-			"integrity": "sha512-7GAsGlK4cNL2OExJH1DzmDeKnRv/LXq0eLUSvudrehVA5Rgg4bIrqEUW29FbKMBRT0ztSqisv7kjP+XIC4ZMNw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.24.7.tgz",
+			"integrity": "sha512-e6q1TiVUzvH9KRvicuxdBTUj4AdKSRwzIyFFnfnezpCfP2/7Qmbb8qbU2j7GODbl4JMkblitCQjKYUaX/qkkwA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
 			},
 			"engines": {
@@ -1291,15 +1299,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-rest-spread": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.5.tgz",
-			"integrity": "sha512-7EauQHszLGM3ay7a161tTQH7fj+3vVM/gThlz5HpFtnygTxjrlvoeq7MPVA1Vy9Q555OB8SnAOsMkLShNkkrHA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.7.tgz",
+			"integrity": "sha512-4QrHAr0aXQCEFni2q4DqKLD31n2DL+RxcwnNjDFkSG0eNQ/xCavnRkfCUjsyqGC2OviNJvZOF/mQqZBw7i2C5Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.23.6",
-				"@babel/helper-plugin-utils": "^7.24.5",
+				"@babel/helper-compilation-targets": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-				"@babel/plugin-transform-parameters": "^7.24.5"
+				"@babel/plugin-transform-parameters": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1309,13 +1317,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-super": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.1.tgz",
-			"integrity": "sha512-oKJqR3TeI5hSLRxudMjFQ9re9fBVUU0GICqM3J1mi8MqlhVr6hC/ZN4ttAyMuQR6EZZIY6h/exe5swqGNNIkWQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.7.tgz",
+			"integrity": "sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
-				"@babel/helper-replace-supers": "^7.24.1"
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-replace-supers": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1325,12 +1333,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-catch-binding": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.24.1.tgz",
-			"integrity": "sha512-oBTH7oURV4Y+3EUrf6cWn1OHio3qG/PVwO5J03iSJmBg6m2EhKjkAu/xuaXaYwWW9miYtvbWv4LNf0AmR43LUA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.24.7.tgz",
+			"integrity": "sha512-uLEndKqP5BfBbC/5jTwPxLh9kqPWWgzN/f8w6UwAIirAEqiIVJWWY312X72Eub09g5KF9+Zn7+hT7sDxmhRuKA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
 			},
 			"engines": {
@@ -1341,13 +1349,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-chaining": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.5.tgz",
-			"integrity": "sha512-xWCkmwKT+ihmA6l7SSTpk8e4qQl/274iNbSKRRS8mpqFR32ksy36+a+LWY8OXCCEefF8WFlnOHVsaDI2231wBg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.7.tgz",
+			"integrity": "sha512-tK+0N9yd4j+x/4hxF3F0e0fu/VdcxU18y5SevtyM/PCFlQvXbR0Zmlo2eBrKtVipGNFzpq56o8WsIIKcJFUCRQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.5",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
 			},
 			"engines": {
@@ -1358,12 +1366,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-parameters": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.5.tgz",
-			"integrity": "sha512-9Co00MqZ2aoky+4j2jhofErthm6QVLKbpQrvz20c3CH9KQCLHyNB+t2ya4/UrRpQGR+Wrwjg9foopoeSdnHOkA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.7.tgz",
+			"integrity": "sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.5"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1373,13 +1381,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-methods": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.1.tgz",
-			"integrity": "sha512-tGvisebwBO5em4PaYNqt4fkw56K2VALsAbAakY0FjTYqJp7gfdrgr7YX76Or8/cpik0W6+tj3rZ0uHU9Oil4tw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.7.tgz",
+			"integrity": "sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.24.1",
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-create-class-features-plugin": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1389,14 +1397,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-property-in-object": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.24.5.tgz",
-			"integrity": "sha512-JM4MHZqnWR04jPMujQDTBVRnqxpLLpx2tkn7iPn+Hmsc0Gnb79yvRWOkvqFOx3Z7P7VxiRIR22c4eGSNj87OBQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.24.7.tgz",
+			"integrity": "sha512-9z76mxwnwFxMyxZWEgdgECQglF2Q7cFLm0kMf8pGwt+GSJsY0cONKj/UuO4bOH0w/uAel3ekS4ra5CEAyJRmDA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-create-class-features-plugin": "^7.24.5",
-				"@babel/helper-plugin-utils": "^7.24.5",
+				"@babel/helper-annotate-as-pure": "^7.24.7",
+				"@babel/helper-create-class-features-plugin": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7",
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
 			},
 			"engines": {
@@ -1407,12 +1415,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-property-literals": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.1.tgz",
-			"integrity": "sha512-LetvD7CrHmEx0G442gOomRr66d7q8HzzGGr4PMHGr+5YIm6++Yke+jxj246rpvsbyhJwCLxcTn6zW1P1BSenqA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.7.tgz",
+			"integrity": "sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1422,12 +1430,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.24.1.tgz",
-			"integrity": "sha512-sJwZBCzIBE4t+5Q4IGLaaun5ExVMRY0lYwos/jNecjMrVCygCdph3IKv0tkP5Fc87e/1+bebAmEAGBfnRD+cnw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.24.7.tgz",
+			"integrity": "sha512-lq3fvXPdimDrlg6LWBoqj+r/DEWgONuwjuOuQCSYgRroXDH/IdM1C0IZf59fL5cHLpjEH/O6opIRBbqv7ELnuA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/helper-plugin-utils": "^7.24.7",
 				"regenerator-transform": "^0.15.2"
 			},
 			"engines": {
@@ -1438,12 +1446,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-reserved-words": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.24.1.tgz",
-			"integrity": "sha512-JAclqStUfIwKN15HrsQADFgeZt+wexNQ0uLhuqvqAUFoqPMjEcFCYZBhq0LUdz6dZK/mD+rErhW71fbx8RYElg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.24.7.tgz",
+			"integrity": "sha512-0DUq0pHcPKbjFZCfTss/pGkYMfy3vFWydkUBd9r0GHpIyfs2eCDENvqadMycRS9wZCXR41wucAfJHJmwA0UmoQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1453,12 +1461,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-shorthand-properties": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.24.1.tgz",
-			"integrity": "sha512-LyjVB1nsJ6gTTUKRjRWx9C1s9hE7dLfP/knKdrfeH9UPtAGjYGgxIbFfx7xyLIEWs7Xe1Gnf8EWiUqfjLhInZA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.24.7.tgz",
+			"integrity": "sha512-KsDsevZMDsigzbA09+vacnLpmPH4aWjcZjXdyFKGzpplxhbeB4wYtury3vglQkg6KM/xEPKt73eCjPPf1PgXBA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1468,13 +1476,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-spread": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.24.1.tgz",
-			"integrity": "sha512-KjmcIM+fxgY+KxPVbjelJC6hrH1CgtPmTvdXAfn3/a9CnWGSTY7nH4zm5+cjmWJybdcPSsD0++QssDsjcpe47g==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.24.7.tgz",
+			"integrity": "sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1484,12 +1492,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-sticky-regex": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.24.1.tgz",
-			"integrity": "sha512-9v0f1bRXgPVcPrngOQvLXeGNNVLc8UjMVfebo9ka0WF3/7+aVUHmaJVT3sa0XCzEFioPfPHZiOcYG9qOsH63cw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.24.7.tgz",
+			"integrity": "sha512-kHPSIJc9v24zEml5geKg9Mjx5ULpfncj0wRpYtxbvKyTtHCYDkVE3aHQ03FrpEo4gEe2vrJJS1Y9CJTaThA52g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1499,12 +1507,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-template-literals": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.1.tgz",
-			"integrity": "sha512-WRkhROsNzriarqECASCNu/nojeXCDTE/F2HmRgOzi7NGvyfYGq1NEjKBK3ckLfRgGc6/lPAqP0vDOSw3YtG34g==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.7.tgz",
+			"integrity": "sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1514,12 +1522,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typeof-symbol": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.5.tgz",
-			"integrity": "sha512-UTGnhYVZtTAjdwOTzT+sCyXmTn8AhaxOS/MjG9REclZ6ULHWF9KoCZur0HSGU7hk8PdBFKKbYe6+gqdXWz84Jg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.7.tgz",
+			"integrity": "sha512-VtR8hDy7YLB7+Pet9IarXjg/zgCMSF+1mNS/EQEiEaUPoFXCVsHG64SIxcaaI2zJgRiv+YmgaQESUfWAdbjzgg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.5"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1529,12 +1537,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-escapes": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.24.1.tgz",
-			"integrity": "sha512-RlkVIcWT4TLI96zM660S877E7beKlQw7Ig+wqkKBiWfj0zH5Q4h50q6er4wzZKRNSYpfo6ILJ+hrJAGSX2qcNw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.24.7.tgz",
+			"integrity": "sha512-U3ap1gm5+4edc2Q/P+9VrBNhGkfnf+8ZqppY71Bo/pzZmXhhLdqgaUl6cuB07O1+AQJtCLfaOmswiNbSQ9ivhw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1544,13 +1552,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-property-regex": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.24.1.tgz",
-			"integrity": "sha512-Ss4VvlfYV5huWApFsF8/Sq0oXnGO+jB+rijFEFugTd3cwSObUSnUi88djgR5528Csl0uKlrI331kRqe56Ov2Ng==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.24.7.tgz",
+			"integrity": "sha512-uH2O4OV5M9FZYQrwc7NdVmMxQJOCCzFeYudlZSzUAHRFeOujQefa92E74TQDVskNHCzOXoigEuoyzHDhaEaK5w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1560,13 +1568,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-regex": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.24.1.tgz",
-			"integrity": "sha512-2A/94wgZgxfTsiLaQ2E36XAOdcZmGAaEEgVmxQWwZXWkGhvoHbaqXcKnU8zny4ycpu3vNqg0L/PcCiYtHtA13g==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.24.7.tgz",
+			"integrity": "sha512-hlQ96MBZSAXUq7ltkjtu3FJCCSMx/j629ns3hA3pXnBXjanNP0LHi+JpPeA81zaWgVK1VGH95Xuy7u0RyQ8kMg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1576,13 +1584,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-sets-regex": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.1.tgz",
-			"integrity": "sha512-fqj4WuzzS+ukpgerpAoOnMfQXwUHFxXUZUE84oL2Kao2N8uSlvcpnAidKASgsNgzZHBsHWvcm8s9FPWUhAb8fA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.7.tgz",
+			"integrity": "sha512-2G8aAvF4wy1w/AGZkemprdGMRg5o6zPNhbHVImRz3lss55TYCBd6xStN19rt8XJHq20sqV0JbyWjOWwQRwV/wg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.24.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1592,27 +1600,27 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.5.tgz",
-			"integrity": "sha512-UGK2ifKtcC8i5AI4cH+sbLLuLc2ktYSFJgBAXorKAsHUZmrQ1q6aQ6i3BvU24wWs2AAKqQB6kq3N9V9Gw1HiMQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.7.tgz",
+			"integrity": "sha512-1YZNsc+y6cTvWlDHidMBsQZrZfEFjRIo/BZCT906PMdzOyXtSLTgqGdrpcuTDCXyd11Am5uQULtDIcCfnTc8fQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.24.4",
-				"@babel/helper-compilation-targets": "^7.23.6",
-				"@babel/helper-plugin-utils": "^7.24.5",
-				"@babel/helper-validator-option": "^7.23.5",
-				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.5",
-				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.1",
-				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.1",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.24.1",
+				"@babel/compat-data": "^7.24.7",
+				"@babel/helper-compilation-targets": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-validator-option": "^7.24.7",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.7",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.7",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.7",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.24.7",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
 				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-				"@babel/plugin-syntax-import-assertions": "^7.24.1",
-				"@babel/plugin-syntax-import-attributes": "^7.24.1",
+				"@babel/plugin-syntax-import-assertions": "^7.24.7",
+				"@babel/plugin-syntax-import-attributes": "^7.24.7",
 				"@babel/plugin-syntax-import-meta": "^7.10.4",
 				"@babel/plugin-syntax-json-strings": "^7.8.3",
 				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
@@ -1624,54 +1632,54 @@
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-				"@babel/plugin-transform-arrow-functions": "^7.24.1",
-				"@babel/plugin-transform-async-generator-functions": "^7.24.3",
-				"@babel/plugin-transform-async-to-generator": "^7.24.1",
-				"@babel/plugin-transform-block-scoped-functions": "^7.24.1",
-				"@babel/plugin-transform-block-scoping": "^7.24.5",
-				"@babel/plugin-transform-class-properties": "^7.24.1",
-				"@babel/plugin-transform-class-static-block": "^7.24.4",
-				"@babel/plugin-transform-classes": "^7.24.5",
-				"@babel/plugin-transform-computed-properties": "^7.24.1",
-				"@babel/plugin-transform-destructuring": "^7.24.5",
-				"@babel/plugin-transform-dotall-regex": "^7.24.1",
-				"@babel/plugin-transform-duplicate-keys": "^7.24.1",
-				"@babel/plugin-transform-dynamic-import": "^7.24.1",
-				"@babel/plugin-transform-exponentiation-operator": "^7.24.1",
-				"@babel/plugin-transform-export-namespace-from": "^7.24.1",
-				"@babel/plugin-transform-for-of": "^7.24.1",
-				"@babel/plugin-transform-function-name": "^7.24.1",
-				"@babel/plugin-transform-json-strings": "^7.24.1",
-				"@babel/plugin-transform-literals": "^7.24.1",
-				"@babel/plugin-transform-logical-assignment-operators": "^7.24.1",
-				"@babel/plugin-transform-member-expression-literals": "^7.24.1",
-				"@babel/plugin-transform-modules-amd": "^7.24.1",
-				"@babel/plugin-transform-modules-commonjs": "^7.24.1",
-				"@babel/plugin-transform-modules-systemjs": "^7.24.1",
-				"@babel/plugin-transform-modules-umd": "^7.24.1",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
-				"@babel/plugin-transform-new-target": "^7.24.1",
-				"@babel/plugin-transform-nullish-coalescing-operator": "^7.24.1",
-				"@babel/plugin-transform-numeric-separator": "^7.24.1",
-				"@babel/plugin-transform-object-rest-spread": "^7.24.5",
-				"@babel/plugin-transform-object-super": "^7.24.1",
-				"@babel/plugin-transform-optional-catch-binding": "^7.24.1",
-				"@babel/plugin-transform-optional-chaining": "^7.24.5",
-				"@babel/plugin-transform-parameters": "^7.24.5",
-				"@babel/plugin-transform-private-methods": "^7.24.1",
-				"@babel/plugin-transform-private-property-in-object": "^7.24.5",
-				"@babel/plugin-transform-property-literals": "^7.24.1",
-				"@babel/plugin-transform-regenerator": "^7.24.1",
-				"@babel/plugin-transform-reserved-words": "^7.24.1",
-				"@babel/plugin-transform-shorthand-properties": "^7.24.1",
-				"@babel/plugin-transform-spread": "^7.24.1",
-				"@babel/plugin-transform-sticky-regex": "^7.24.1",
-				"@babel/plugin-transform-template-literals": "^7.24.1",
-				"@babel/plugin-transform-typeof-symbol": "^7.24.5",
-				"@babel/plugin-transform-unicode-escapes": "^7.24.1",
-				"@babel/plugin-transform-unicode-property-regex": "^7.24.1",
-				"@babel/plugin-transform-unicode-regex": "^7.24.1",
-				"@babel/plugin-transform-unicode-sets-regex": "^7.24.1",
+				"@babel/plugin-transform-arrow-functions": "^7.24.7",
+				"@babel/plugin-transform-async-generator-functions": "^7.24.7",
+				"@babel/plugin-transform-async-to-generator": "^7.24.7",
+				"@babel/plugin-transform-block-scoped-functions": "^7.24.7",
+				"@babel/plugin-transform-block-scoping": "^7.24.7",
+				"@babel/plugin-transform-class-properties": "^7.24.7",
+				"@babel/plugin-transform-class-static-block": "^7.24.7",
+				"@babel/plugin-transform-classes": "^7.24.7",
+				"@babel/plugin-transform-computed-properties": "^7.24.7",
+				"@babel/plugin-transform-destructuring": "^7.24.7",
+				"@babel/plugin-transform-dotall-regex": "^7.24.7",
+				"@babel/plugin-transform-duplicate-keys": "^7.24.7",
+				"@babel/plugin-transform-dynamic-import": "^7.24.7",
+				"@babel/plugin-transform-exponentiation-operator": "^7.24.7",
+				"@babel/plugin-transform-export-namespace-from": "^7.24.7",
+				"@babel/plugin-transform-for-of": "^7.24.7",
+				"@babel/plugin-transform-function-name": "^7.24.7",
+				"@babel/plugin-transform-json-strings": "^7.24.7",
+				"@babel/plugin-transform-literals": "^7.24.7",
+				"@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
+				"@babel/plugin-transform-member-expression-literals": "^7.24.7",
+				"@babel/plugin-transform-modules-amd": "^7.24.7",
+				"@babel/plugin-transform-modules-commonjs": "^7.24.7",
+				"@babel/plugin-transform-modules-systemjs": "^7.24.7",
+				"@babel/plugin-transform-modules-umd": "^7.24.7",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
+				"@babel/plugin-transform-new-target": "^7.24.7",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+				"@babel/plugin-transform-numeric-separator": "^7.24.7",
+				"@babel/plugin-transform-object-rest-spread": "^7.24.7",
+				"@babel/plugin-transform-object-super": "^7.24.7",
+				"@babel/plugin-transform-optional-catch-binding": "^7.24.7",
+				"@babel/plugin-transform-optional-chaining": "^7.24.7",
+				"@babel/plugin-transform-parameters": "^7.24.7",
+				"@babel/plugin-transform-private-methods": "^7.24.7",
+				"@babel/plugin-transform-private-property-in-object": "^7.24.7",
+				"@babel/plugin-transform-property-literals": "^7.24.7",
+				"@babel/plugin-transform-regenerator": "^7.24.7",
+				"@babel/plugin-transform-reserved-words": "^7.24.7",
+				"@babel/plugin-transform-shorthand-properties": "^7.24.7",
+				"@babel/plugin-transform-spread": "^7.24.7",
+				"@babel/plugin-transform-sticky-regex": "^7.24.7",
+				"@babel/plugin-transform-template-literals": "^7.24.7",
+				"@babel/plugin-transform-typeof-symbol": "^7.24.7",
+				"@babel/plugin-transform-unicode-escapes": "^7.24.7",
+				"@babel/plugin-transform-unicode-property-regex": "^7.24.7",
+				"@babel/plugin-transform-unicode-regex": "^7.24.7",
+				"@babel/plugin-transform-unicode-sets-regex": "^7.24.7",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
 				"babel-plugin-polyfill-corejs2": "^0.4.10",
 				"babel-plugin-polyfill-corejs3": "^0.10.4",
@@ -1701,9 +1709,9 @@
 			}
 		},
 		"node_modules/@babel/register": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.23.7.tgz",
-			"integrity": "sha512-EjJeB6+kvpk+Y5DAkEAmbOBEFkh9OASx0huoEkqYTFxAZHzOAX2Oh5uwAUuL2rUddqfM0SA+KPXV2TbzoZ2kvQ==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.24.6.tgz",
+			"integrity": "sha512-WSuFCc2wCqMeXkz/i3yfAAsxwWflEgbVkZzivgAmXl/MxrXeoYFZOOPllbC8R8WTF7u61wSRQtDVZ1879cdu6w==",
 			"dependencies": {
 				"clone-deep": "^4.0.1",
 				"find-cache-dir": "^2.0.0",
@@ -1725,9 +1733,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-			"integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
+			"integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
 			"dev": true,
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
@@ -1737,31 +1745,31 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.24.0",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
-			"integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+			"integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
 			"dependencies": {
-				"@babel/code-frame": "^7.23.5",
-				"@babel/parser": "^7.24.0",
-				"@babel/types": "^7.24.0"
+				"@babel/code-frame": "^7.24.7",
+				"@babel/parser": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
-			"integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+			"integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
 			"dependencies": {
-				"@babel/code-frame": "^7.24.2",
-				"@babel/generator": "^7.24.5",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-hoist-variables": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.24.5",
-				"@babel/parser": "^7.24.5",
-				"@babel/types": "^7.24.5",
+				"@babel/code-frame": "^7.24.7",
+				"@babel/generator": "^7.24.7",
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-function-name": "^7.24.7",
+				"@babel/helper-hoist-variables": "^7.24.7",
+				"@babel/helper-split-export-declaration": "^7.24.7",
+				"@babel/parser": "^7.24.7",
+				"@babel/types": "^7.24.7",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -1770,12 +1778,12 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-			"integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+			"integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.24.1",
-				"@babel/helper-validator-identifier": "^7.24.5",
+				"@babel/helper-string-parser": "^7.24.7",
+				"@babel/helper-validator-identifier": "^7.24.7",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -1828,9 +1836,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.10.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+			"integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
 			"dev": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1909,6 +1917,7 @@
 			"version": "0.11.14",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
 			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+			"deprecated": "Use @eslint/config-array instead",
 			"dev": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^2.0.2",
@@ -1958,7 +1967,104 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
 			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"peer": true,
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"peer": true
+		},
+		"node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"peer": true,
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.5",
@@ -2004,9 +2110,9 @@
 			}
 		},
 		"node_modules/@natlibfi/eslint-config-melinda-backend": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.4.tgz",
-			"integrity": "sha512-0empL237DfX80LCFC7+pMXojsfMThBblViIT1MUllyYF0yNvmGSFTL1Ycf/HDfz61uX3MxJhE+ab3mQUWZpM3w==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.5.tgz",
+			"integrity": "sha512-7UE/las5+S4XiQkFO1Z0qHqKJaPUgLqvCGEgKy0aY3A0CoyZAaEi/3K0UUYgw9C7MAxySbGKSVr1ESv3Ub3vUg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/eslint-parser": "^7.22.15",
@@ -2022,15 +2128,15 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-8.1.1.tgz",
-			"integrity": "sha512-bUBeyfg0aspdx2Ia7NPklVHSd/bdjrkPbtImef1+Ry5JR4VsJzlG9inIyjwmOxNFyv/vm65jdBqtIzTsSSHhbw==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-9.0.0.tgz",
+			"integrity": "sha512-ZTKpyrEc2XHMGIhNGvNLOV1p0uHRY/Zr7jZF4n+Q3cyLdT5uLmKnv16W2yPSdzk1NaNdl0nNxqnrQ+XBrtZ2Cg==",
 			"dependencies": {
-				"debug": "^4.3.4",
+				"debug": "^4.3.5",
 				"jsonschema": "^1.4.1"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@natlibfi/marc-record-serializers": {
@@ -2051,18 +2157,33 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@natlibfi/marc-record-serializers/node_modules/@natlibfi/marc-record": {
+			"version": "8.1.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-8.1.3.tgz",
+			"integrity": "sha512-u2MU4n1Z6WblH3vSEKTUoBO/hUaD36ff/dWpzFukF6k0/wTzwbBKlonAP+xhPtak9f7UNv2mPQOSZ7XSbZwiYw==",
+			"dependencies": {
+				"debug": "^4.3.4",
+				"jsonschema": "^1.4.1"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.6.tgz",
-			"integrity": "sha512-BlAfjt1VH789dqmvMzKqGG8Gwj2TCkMGTiQ9FOIxbmWg1Wb6C6/OJCDSshB0JW7XNMMiVS4ZkOfDrOt4q1kmgA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.3.0.tgz",
+			"integrity": "sha512-QyEom2TYLrJLvf5drDmzLhqnyDjhesrm3xcZdrFosmEuBl4OFkHRQtPs3aEYSpWQ3Jzhyol+AGWWdxJMk3iBiQ==",
 			"dependencies": {
 				"base64-url": "^2.3.3",
 				"debug": "^4.3.4",
 				"express-winston": "^4.2.0",
-				"moment": "^2.29.4",
+				"moment": "^2.30.1",
+				"nodemailer": "^6.9.13",
+				"nodemailer-express-handlebars": "^6.1.2",
 				"pretty-print-ms": "^1.0.5",
 				"uuid": "^9.0.1",
-				"winston": "^3.11.0"
+				"winston": "^3.13.0",
+				"yargs": "^17.7.2"
 			},
 			"bin": {
 				"gen-encryption-key": "dist/gen-encryption-key.js",
@@ -2073,19 +2194,18 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.13",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.13.tgz",
-			"integrity": "sha512-xR3lD0n80DSnCRlYfIQ3ttQtlgTQ8t9B9DtASdeKqwKxUS72qTM+nXYmkFv1HmxJC9n3J05QcAjAm7ATjmK96A==",
+			"version": "13.0.15",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.15.tgz",
+			"integrity": "sha512-n21p4O5qFC7L5lMFvMSo2ERKCglXgVF3vFetkV6UBCQVqRnQ1hnj9aUp9UjZrEu0rzaB/I8OzlG1M8ldIfKbfQ==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^8.1.0",
+				"@natlibfi/marc-record": "^9.0.0",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
-				"@natlibfi/sru-client": "^6.0.8",
-				"debug": "^4.3.4",
-				"deep-eql": "^4.1.3",
-				"http-status": "^1.7.3",
+				"@natlibfi/sru-client": "^6.0.11",
+				"debug": "^4.3.5",
+				"deep-eql": "^4.1.4",
+				"http-status": "^1.7.4",
 				"moment": "^2.30.1",
-				"nock": "^13.5.0",
-				"node-fetch": "^2.7.0"
+				"nock": "^13.5.4"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2107,11 +2227,11 @@
 			}
 		},
 		"node_modules/@natlibfi/sru-client": {
-			"version": "6.0.9",
-			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.9.tgz",
-			"integrity": "sha512-I9mIy+2QWxhBTSiJkQ0vz8WwLOuCCVKkQJ8JHDvSc4UwToo1YzPa8BkuTOgMv2+dai7swJWXAY9CzUTR3i8MmQ==",
+			"version": "6.0.11",
+			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.11.tgz",
+			"integrity": "sha512-kUX9IHiSGNFuXs+zjRBPlcLB3kbZK5zEPmgJMdADme8stNuRY0t+9WS8TMLgO+GjEuHUM97Ej9JF0EgiwNWwnQ==",
 			"dependencies": {
-				"debug": "^4.3.4",
+				"debug": "^4.3.5",
 				"http-status": "^1.7.4",
 				"node-fetch": "^2.7.0",
 				"xml2js": "^0.6.2"
@@ -2169,6 +2289,16 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@types/json-schema": {
@@ -2365,16 +2495,10 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"dev": true
-		},
 		"node_modules/acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2576,8 +2700,7 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"node_modules/base64-url": {
 			"version": "2.3.3",
@@ -2603,27 +2726,26 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.23.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-			"integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+			"version": "4.23.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+			"integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2639,10 +2761,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001587",
-				"electron-to-chromium": "^1.4.668",
+				"caniuse-lite": "^1.0.30001629",
+				"electron-to-chromium": "^1.4.796",
 				"node-releases": "^2.0.14",
-				"update-browserslist-db": "^1.0.13"
+				"update-browserslist-db": "^1.0.16"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -2685,9 +2807,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001617",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001617.tgz",
-			"integrity": "sha512-mLyjzNI9I+Pix8zwcrpxEbGlfqOkF9kM3ptzmKNw5tizSyYwMe+nGLTqMK9cO+0E+Bh6TsBxNAaHWEM8xwSsmA==",
+			"version": "1.0.30001640",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
+			"integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2807,9 +2929,9 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
 			"dev": true,
 			"engines": {
 				"node": ">= 6"
@@ -2832,9 +2954,9 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
 		},
 		"node_modules/core-js": {
-			"version": "3.37.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
-			"integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==",
+			"version": "3.37.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
+			"integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -2843,9 +2965,9 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.37.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
-			"integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
+			"version": "3.37.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
+			"integrity": "sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.23.0"
@@ -2877,7 +2999,6 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-			"dev": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -2939,9 +3060,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -2955,9 +3076,9 @@
 			}
 		},
 		"node_modules/deep-eql": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+			"integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
 			"dependencies": {
 				"type-detect": "^4.0.0"
 			},
@@ -3038,10 +3159,16 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"peer": true
+		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.762",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.762.tgz",
-			"integrity": "sha512-rrFvGweLxPwwSwJOjIopy3Vr+J3cIPtZzuc74bmlvmBIgQO3VYJDvVrlj94iKZ3ukXUH64Ex31hSfRTLqvjYJQ=="
+			"version": "1.4.816",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.816.tgz",
+			"integrity": "sha512-EKH5X5oqC6hLmiS7/vYtZHZFTNdhsYG5NVPRN6Yn0kQHNBlT59+xSM8HBy66P5fxWpKgZbPqb+diC64ng295Jw=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -3728,6 +3855,58 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/express-handlebars": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-7.1.3.tgz",
+			"integrity": "sha512-O0W4n14iQ8+iFIDdiMh9HRI2nbVQJ/h1qndlD1TXWxxcfbKjKoqJh+ti2tROkyx4C4VQrt0y3bANBQ5auQAiew==",
+			"peer": true,
+			"dependencies": {
+				"glob": "^10.4.2",
+				"graceful-fs": "^4.2.11",
+				"handlebars": "^4.7.8"
+			},
+			"engines": {
+				"node": ">=v16"
+			}
+		},
+		"node_modules/express-handlebars/node_modules/glob": {
+			"version": "10.4.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
+			"integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
+			"peer": true,
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/express-handlebars/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/express-winston": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/express-winston/-/express-winston-4.2.0.tgz",
@@ -3804,9 +3983,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -3876,6 +4055,22 @@
 			"dev": true,
 			"dependencies": {
 				"is-callable": "^1.1.3"
+			}
+		},
+		"node_modules/foreground-child": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+			"integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+			"peer": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/fs-readdir-recursive": {
@@ -3996,6 +4191,7 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
 			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
@@ -4111,11 +4307,38 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"peer": true
+		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
+		},
+		"node_modules/handlebars": {
+			"version": "4.7.8",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"peer": true,
+			"dependencies": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"wordwrap": "^1.0.0"
+			},
+			"bin": {
+				"handlebars": "bin/handlebars"
+			},
+			"engines": {
+				"node": ">=0.4.7"
+			},
+			"optionalDependencies": {
+				"uglify-js": "^3.1.4"
+			}
 		},
 		"node_modules/has-bigints": {
 			"version": "1.0.2",
@@ -4261,6 +4484,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
@@ -4360,12 +4584,15 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+			"integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
 			"dev": true,
 			"dependencies": {
-				"hasown": "^2.0.0"
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -4758,8 +4985,7 @@
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 		},
 		"node_modules/isobject": {
 			"version": "3.0.1",
@@ -4767,6 +4993,24 @@
 			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+			"integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+			"peer": true,
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
 		"node_modules/js-tokens": {
@@ -4960,12 +5204,12 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
 			"dev": true,
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -4987,6 +5231,24 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"peer": true,
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
 		"node_modules/moment": {
 			"version": "2.30.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -5005,6 +5267,12 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node_modules/neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"peer": true
 		},
 		"node_modules/nock": {
 			"version": "13.5.4",
@@ -5062,10 +5330,30 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
 			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
 		},
+		"node_modules/nodemailer": {
+			"version": "6.9.14",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.14.tgz",
+			"integrity": "sha512-Dobp/ebDKBvz91sbtRKhcznLThrKxKt97GI2FAlAyy+fk19j73Uz3sBXolVtmcXjaorivqsbbbjDY+Jkt4/bQA==",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/nodemailer-express-handlebars": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/nodemailer-express-handlebars/-/nodemailer-express-handlebars-6.1.2.tgz",
+			"integrity": "sha512-p5ZKPe8PmiDZquNqi+uDKE1eKXOcqOVPdnmhWELCT1HHoaYXcVwM7wQE1R7wtPPracZRH2hL7mEWiXhVwr5hng==",
+			"engines": {
+				"node": "14.* || 16.* || >= 18"
+			},
+			"peerDependencies": {
+				"express-handlebars": ">= 6.0.0",
+				"nodemailer": ">= 6.0.0"
+			}
+		},
 		"node_modules/nodemon": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.0.tgz",
-			"integrity": "sha512-xqlktYlDMCepBJd43ZQhjWwMw2obW/JRvkrLxq5RCNcuDDX1DbcPT+qT1IlIIdf+DhnWs90JpTMe+Y5KxOchvA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.4.tgz",
+			"integrity": "sha512-wjPBbFhtpJwmIeY2yP7QF+UKzPfltVGtfce1g/bB15/8vCGZj8uxD62b/b9M9/WVgme0NZudpownKN+c0plXlQ==",
 			"dev": true,
 			"dependencies": {
 				"chokidar": "^3.5.2",
@@ -5124,21 +5412,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/nopt": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-			"integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
-			"dev": true,
-			"dependencies": {
-				"abbrev": "1"
-			},
-			"bin": {
-				"nopt": "bin/nopt.js"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5149,10 +5422,13 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+			"integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
 			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -5277,6 +5553,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+			"peer": true
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5367,7 +5649,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -5377,6 +5658,31 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
+		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.0.tgz",
+			"integrity": "sha512-CQl19J/g+Hbjbv4Y3mFNNXFEL/5t/KCg8POCuUqd4rMKjGG+j1ybER83hxV58zL+dFI1PTkt3GNFSHRt+d8qEQ==",
+			"peer": true,
+			"engines": {
+				"node": "14 || >=16.14"
+			}
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -5393,9 +5699,9 @@
 			"integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -5720,6 +6026,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.3"
@@ -5817,9 +6124,9 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-			"integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+			"integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
 		},
 		"node_modules/semver": {
 			"version": "6.3.1",
@@ -5876,7 +6183,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -5888,7 +6194,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -5909,6 +6214,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/simple-swizzle": {
@@ -6011,6 +6328,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"peer": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/string.prototype.trim": {
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
@@ -6064,6 +6396,19 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -6138,13 +6483,10 @@
 			}
 		},
 		"node_modules/touch": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-			"integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+			"integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
 			"dev": true,
-			"dependencies": {
-				"nopt": "~1.0.10"
-			},
 			"bin": {
 				"nodetouch": "bin/nodetouch.js"
 			}
@@ -6301,9 +6643,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+			"integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
 			"dev": true,
 			"peer": true,
 			"bin": {
@@ -6312,6 +6654,19 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/uglify-js": {
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.18.0.tgz",
+			"integrity": "sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/unbox-primitive": {
@@ -6376,9 +6731,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.15",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.15.tgz",
-			"integrity": "sha512-K9HWH62x3/EalU1U6sjSZiylm9C8tgq2mSvshZpqc7QE69RaA2qjhkW2HlNA0tFpEbtyFz7HTqbSdN4MSwUodA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+			"integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6395,7 +6750,7 @@
 			],
 			"dependencies": {
 				"escalade": "^3.1.2",
-				"picocolors": "^1.0.0"
+				"picocolors": "^1.0.1"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"
@@ -6468,7 +6823,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -6557,6 +6911,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+			"peer": true
+		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -6572,6 +6932,57 @@
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"peer": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"peer": true
 		},
 		"node_modules/wrap-ansi/node_modules/ansi-styles": {
 			"version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/passport-melinda-crowd-js.git"
 	},
 	"license": "MIT",
-	"version": "3.0.5",
+	"version": "3.0.6-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -32,8 +32,8 @@
 		"watch:test": "cross-env DEBUG=@natlibfi/* NODE_ENV=test nodemon"
 	},
 	"dependencies": {
-		"@natlibfi/melinda-backend-commons": "^2.2.6",
-		"@natlibfi/melinda-commons": "^13.0.13",
+		"@natlibfi/melinda-backend-commons": "^2.3.0",
+		"@natlibfi/melinda-commons": "^13.0.15",
 		"@natlibfi/passport-atlassian-crowd": "^3.0.1",
 		"passport": "^0.7.0",
 		"passport-http": "^0.3.0",
@@ -41,15 +41,15 @@
 		"uuid": "^9.0.1"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.24.5",
-		"@babel/core": "^7.24.5",
-		"@babel/node": "^7.23.9",
-		"@babel/preset-env": "^7.24.5",
-		"@babel/register": "^7.23.7",
-		"@natlibfi/eslint-config-melinda-backend": "^3.0.4",
+		"@babel/cli": "^7.24.7",
+		"@babel/core": "^7.24.7",
+		"@babel/node": "^7.24.7",
+		"@babel/preset-env": "^7.24.7",
+		"@babel/register": "^7.24.6",
+		"@natlibfi/eslint-config-melinda-backend": "^3.0.5",
 		"cross-env": "^7.0.3",
 		"eslint": "^8.57.0",
-		"nodemon": "^3.1.0"
+		"nodemon": "^3.1.4"
 	},
 	"eslintConfig": {
 		"extends": "@natlibfi/melinda-backend"


### PR DESCRIPTION
* Bump @natlibfi/melinda-commons in the production-dependencies group (#40)

* Bump the development-dependencies group across 1 directory with 7 updates (#49)

| Package | From | To |
| --- | --- | --- |
| [@babel/cli](https://github.com/babel/babel/tree/HEAD/packages/babel-cli) | `7.24.5` | `7.24.7` | | [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core) | `7.24.5` | `7.24.7` | | [@babel/node](https://github.com/babel/babel/tree/HEAD/packages/babel-node) | `7.23.9` | `7.24.7` | | [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env) | `7.24.5` | `7.24.7` | | [@natlibfi/eslint-config-melinda-backend](https://github.com/natlibfi/eslint-config-melinda-backend) | `3.0.4` | `3.0.5` | | [nodemon](https://github.com/remy/nodemon) | `3.1.0` | `3.1.4` |

* Bump braces from 3.0.2 to 3.0.3 (#50)

* Update deps

* Node-tests: remove v21

* 3.0.6-alpha.2